### PR TITLE
Have rootid cypress:open automatically load the sites specs in the Cypress GUI

### DIFF
--- a/src/Commands/Test/RunSiteTests.php
+++ b/src/Commands/Test/RunSiteTests.php
@@ -55,7 +55,7 @@ class RunSiteTests extends \Robo\Tasks {
         $site_data = $this->getSite();
         $test_url = $this->getLocalSiteRoot($site_data);
         $_ENV['CYPRESS_BASE_URL'] = $test_url;
-        chdir('./.tests');
+        // chdir('./.tests');
         $this->openCypressTestResults($test_url);
     }
 
@@ -113,6 +113,11 @@ class RunSiteTests extends \Robo\Tasks {
     }
 
     private function openCypressTestResults($test_url) {
-        $this->taskExec('cypress')->args('open', '--env')->rawArg('BASE_PATH=' . $base_path)->run();
+        $this
+            ->taskExec('cypress')
+            ->args('open', '--env')
+            ->rawArg('BASE_PATH=' . $test_url)
+            ->rawArg('--project ./.tests')
+            ->run();
     }
 }

--- a/src/Commands/Test/RunSiteTests.php
+++ b/src/Commands/Test/RunSiteTests.php
@@ -55,7 +55,6 @@ class RunSiteTests extends \Robo\Tasks {
         $site_data = $this->getSite();
         $test_url = $this->getLocalSiteRoot($site_data);
         $_ENV['CYPRESS_BASE_URL'] = $test_url;
-        // chdir('./.tests');
         $this->openCypressTestResults($test_url);
     }
 


### PR DESCRIPTION
Instead of changing into the .tests directory (which doesn't affect which specs are loaded) this passes an argument to look in the .tests directory. Now when you use the cypress:open command the Cypress GUI automatically displays all the spec in the .tests/cypress/integration folder :)