### PR TITLE
Check for and remove .htaccess in downloaded files

### DIFF
--- a/src/Traits/SiteOperations.php
+++ b/src/Traits/SiteOperations.php
@@ -61,6 +61,9 @@ trait SiteOperations {
         $this->say('Unzipping archive');
 
         @$this->taskExec('tar')->args('-xvf', $tmp_file , '-C', $tmp)->rawArg('>/dev/null')->run();
+        if(file_exists ($tmp .'/files_' . $env . '/.htaccess')) {
+            $this->_exec('rm ' . $tmp . '/files_' . $env. '/.htaccess');
+        }
         $this->say('Copying Files');
         $this->_copyDir($tmp .'/files_' . $env, $path);
 


### PR DESCRIPTION
Some sites (such as GRID Alternatives) have an .htaccess file the files directory. When the script is copying the files from the unstuffed Pantheon archive to the files directory, attempting to copy the .htaccess file causes an error on Mac: 
```
➜  Copying Files
 [error]  Failed to copy "/tmp/files_live/.htaccess" to "./sites/default/files/.htaccess" because target file could not be opened for writing.
```

We don't need that .htaccess file, so I just added a quick check for existence and deletion if yes.