### PR TITLE
Add code to support use of pantheon environments

### DIFF
--- a/src/Commands/Sync/SyncSiteData.php
+++ b/src/Commands/Sync/SyncSiteData.php
@@ -5,37 +5,39 @@ namespace RootidCLI\Commands\Sync;
 use RootidCLI\Traits\SiteInfo;
 use RootidCLI\Traits\SiteOperations;
 
-class SyncSiteData extends \Robo\Tasks {
-    use SiteInfo;
-    use SiteOperations;
+class SyncSiteData extends \Robo\Tasks
+{
+  use SiteInfo;
+  use SiteOperations;
 
-    /**
-     * Syncs Site Data
-     *
-     * @command sync
-     *
-     * @option nodb Does not sync site database.
-     * @option files Syncs site files.
-     * @option env Specific site environment to sync from.
-     *
-     * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
-     * @usage Logs in a user with a previously saved machine token.
-     * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
-     */
-    public function doSync($options = ['nodb' => NULL, 'files' => NULL, 'env' => 'dev']) {
-        $site_data = $this->getSite();
+  /**
+   * Syncs Site Data
+   *
+   * @command sync
+   *
+   * @option nodb Does not sync site database.
+   * @option files Syncs site files.
+   * @option env Specific site environment to sync from.
+   *
+   * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
+   * @usage Logs in a user with a previously saved machine token.
+   * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
+   */
+  public function doSync($options = ['nodb' => NULL, 'files' => NULL, 'env' => 'dev'])
+  {
+    $site_data = $this->getSite();
 
-        // If the env isn't live, dev, or test, then make sure the env actually exists on Pantheon.
-        if(!in_array($options['env'], ['live', 'dev', 'test'])) {
-            //TODO: Use terminus to verify this env exists.
-        }
+    // If the env isn't live, dev, or test, then make sure the env actually exists on Pantheon.
+    if (in_array($options['env'], ['live', 'dev', 'test']) || in_array($options['env'], $this->getSiteEnvs($site_data))) {
+      if (!$options['nodb']) {
+        $this->fetchSiteDB($site_data->name, $options['env']);
+      }
 
-        if(!$options['nodb']) {
-            $this->fetchSiteDB($site_data->name, $options['env']);
-        }
-
-        if($options['files']) {
-            $this->fetchSiteFiles($site_data, $options['env']);
-        }
+      if ($options['files']) {
+        $this->fetchSiteFiles($site_data, $options['env']);
+      }
+    } else {
+      exit("Sync failed: That environment doesn't appear to exist");
     }
+  }
 }

--- a/src/Commands/Test/RunSiteTests.php
+++ b/src/Commands/Test/RunSiteTests.php
@@ -5,148 +5,165 @@ namespace RootidCLI\Commands\Test;
 use RootidCLI\Traits\SiteInfo;
 use RootidCLI\Traits\SiteOperations;
 
-class RunSiteTests extends \Robo\Tasks {
-    use SiteInfo;
-    use SiteOperations;
+class RunSiteTests extends \Robo\Tasks
+{
+  use SiteInfo;
+  use SiteOperations;
 
-    public function __construct() {
-        $this->backstop_config = BASE_DIR . "/test-runners/backstop-config.js";
-    }
+  public function __construct()
+  {
+    $this->backstop_config = BASE_DIR . "/test-runners/backstop-config.js";
+  }
 
 
-    /**
-     * Runs tests against the local version of the site.
-     *
-     * @command cypress:run
-     *
-     *
-     * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
-     * @usage Logs in a user with a previously saved machine token.
-     * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
-     *
-     * @alias cypruss
-     */
-    public function runIntegrationTests() {
-        $site_data = $this->getSite();
+  /**
+   * Runs tests against the local version of the site.
+   *
+   * @command cypress:run
+   *
+   *
+   * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
+   * @usage Logs in a user with a previously saved machine token.
+   * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
+   *
+   * @alias cypruss
+   */
+  public function runIntegrationTests()
+  {
+    $site_data = $this->getSite();
 
-        $test_url = $this->getLocalSiteRoot($site_data);
+    $test_url = $this->getLocalSiteRoot($site_data);
 
-        $_ENV['CYPRESS_BASE_URL'] = $test_url;
+    $_ENV['CYPRESS_BASE_URL'] = $test_url;
 
-        //chdir('./.tests');
+    //chdir('./.tests');
 
-        //$tests = file_get_contents('elements.json');
-        //$_ENV['TEST_ELEMENTS'] = $tests;
+    //$tests = file_get_contents('elements.json');
+    //$_ENV['TEST_ELEMENTS'] = $tests;
 
-        //if($options['generate']) {
-        //    $this->generateReferenceImages();
-        //}
+    //if($options['generate']) {
+    //    $this->generateReferenceImages();
+    //}
 
-        $this->runCypressTests($test_url);
-    }
+    $this->runCypressTests($test_url);
+  }
 
-    /**
-     * Runs tests against the local version of the site.
-     *
-     * @command cypress:open
-     *
-     */
-    public function openIntegrationTestResults() {
-        $site_data = $this->getSite();
-        $test_url = $this->getLocalSiteRoot($site_data);
-        $_ENV['CYPRESS_BASE_URL'] = $test_url;
-        $this->openCypressTestResults($test_url);
-    }
+  /**
+   * Runs tests against the local version of the site.
+   *
+   * @command cypress:open
+   *
+   */
+  public function openIntegrationTestResults()
+  {
+    $site_data = $this->getSite();
+    $test_url = $this->getLocalSiteRoot($site_data);
+    $_ENV['CYPRESS_BASE_URL'] = $test_url;
+    $this->openCypressTestResults($test_url);
+  }
 
-    /**
-     * Runs tests against the local version of the site.
-     *
-     * @command backstop
-     *
-     * @option env Specific site environment to sync from.
-     * @option generate If set this will create references images as well as run a test.
-     * @option test If set this allows you to set a specific test url [default: local site]
-     * @option reference If set this allows you to set a specific reference url [default: live site]
-     * @option debug If set this toggles the browser to run tests in non-headless, visible mode so you can watch
-     *
-     * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
-     * @usage Logs in a user with a previously saved machine token.
-     * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
-     */
-    public function runTests($options = ['env' => 'live', 'generate' => NULL, 'test' => NULL, 'reference' => NULL, 'debug' => NULL]) {
-        $site_data = $this->getSite();
+  /**
+   * Runs tests against the local version of the site.
+   *
+   * @command backstop
+   *
+   * @option env Specific site environment to sync from.
+   * @option generate If set this will create references images as well as run a test.
+   * @option test If set this allows you to use either a pantheon environment or a specific test url [default: local site]
+   * @option ref If set this allows you to use either a pantheon environment or a specific reference url [default: live site]
+   * @option debug If set this toggles the browser to run tests in non-headless, visible mode so you can watch
+   *
+   * @usage --machine-token=<machine_token> Logs in a user granted the machine token <machine_token>.
+   * @usage Logs in a user with a previously saved machine token.
+   * @usage --email=<email> Logs in a user with a previously saved machine token belonging to <email>.
+   */
+  public function runTests($options = ['env' => 'live', 'generate' => NULL, 'test' => NULL, 'ref' => NULL, 'debug' => NULL])
+  {
+    $site_data = $this->getSite();
 
-        // If the env isn't live, dev, or test, then make sure the env actually exists on Pantheon.
-        if(!in_array($options['env'], ['live', 'dev', 'test'])) {
-            //TODO: Use terminus to verify this env exists.
-        }
-
-        if ($options['reference'] !== NULL) {
-            if (strpos($options['reference'], "http") === 0) {
-                $ref_url = $options['reference'];
-            }
-            else {
-                $ref_url = "http://" . $options['reference'];
-            }
-        }
-        else {
-            // TODO: Currently hard-coding http auth, but this should be configurable.
-            $ref_url = "https://rootid:rootid@" . $options['env'] . '-' . $site_data->name . ".pantheonsite.io";
-        }
-
-        if ($options['test'] !== NULL) {
-            if (strpos($options['test'], "http") === 0) {
-                $test_url = $options['test'];
-            }
-            else {
-                $test_url = "http://" . $options['test'];
-            }
+    if ($options['ref'] !== NULL) {
+      if (in_array($options['ref'], $this->getSiteEnvs($site_data))) {
+        // TODO: Currently hard-coding http auth, but this should be configurable.
+        $ref_url = "https://rootid:rootid@" . $options['ref'] . '-' . $site_data->name . ".pantheonsite.io";
+      } else {
+        if (strpos($options['ref'], "http") === 0) {
+          $ref_url = $options['ref'];
         } else {
-            $test_url = $this->getLocalSiteRoot($site_data);
+          $ref_url = "http://" . $options['ref'];
         }
+      }
+    } else {
+      if ($options['env'] !== NULL && (in_array($options['env'], ['live', 'dev', 'test']) || in_array($options['env'], $this->getSiteEnvs($site_data)))) {
+        // TODO: Currently hard-coding http auth, but this should be configurable.
+        $ref_url = "https://rootid:rootid@" . $options['env'] . '-' . $site_data->name . ".pantheonsite.io";
+      } else {
+        $ref_url = "https://rootid:rootid@.live-" . $site_data->name . ".pantheonsite.io";
+      }
+    }
 
-        $_ENV['TESTING_TESTING'] = "hello?";
-
-        if ($options['debug']) {
-            $_ENV['BACKSTOP_DEBUG'] = "debug";
+    if ($options['test'] !== NULL) {
+      if (in_array($options['test'], $this->getSiteEnvs($site_data))) {
+        // TODO: Currently hard-coding http auth, but this should be configurable.
+        $test_url = "https://rootid:rootid@" . $options['test'] . '-' . $site_data->name . ".pantheonsite.io";
+      } else {
+        if (strpos($options['test'], "http") === 0) {
+          $test_url = $options['test'];
+        } else {
+          $test_url = "http://" . $options['test'];
         }
-
-        // See /test-runners/backstop-config.js for when these get used.
-        $_ENV['BACKSTOP_REF_URL'] = $ref_url;
-        $_ENV['BACKSTOP_TEST_URL'] = $test_url;
-
-        chdir('./.tests');
-
-        $tests = file_get_contents('elements.json');
-        $_ENV['TEST_ELEMENTS'] = $tests;
-
-        if($options['generate']) {
-            $this->generateReferenceImages();
-        }
-
-        $this->runVisualRegressionTests();
+      }
+    } else {
+      $test_url = $this->getLocalSiteRoot($site_data);
     }
 
-    private function generateReferenceImages() {
-        $this->taskExec('backstop')->args('reference', '--config=' . $this->backstop_config)->run();
+
+    if ($options['debug']) {
+      $_ENV['BACKSTOP_DEBUG'] = "debug";
     }
 
-    private function runVisualRegressionTests() {
-        // Run the tests set up in the ROOT/.tests/elements.json file.
-        $this->taskExec('backstop')->args('test', '--config=' . $this->backstop_config)->run();
-        $this->taskExec('backstop')->args('openReport', '--config=' . $this->backstop_config)->run();
+    // See /test-runners/backstop-config.js for when these get used.
+    $_ENV['BACKSTOP_REF_URL'] = $ref_url;
+    $_ENV['BACKSTOP_TEST_URL'] = $test_url;
+
+    chdir('./.tests');
+
+    $tests = file_get_contents('elements.json');
+    $_ENV['TEST_ELEMENTS'] = $tests;
+
+    // echo ("Reference: \n" . $ref_url . "\n");
+    // echo ("Test: \n" . $test_url . "\n");
+
+    if ($options['generate']) {
+      $this->generateReferenceImages();
     }
 
-    private function runCypressTests($base_path) {
-        $this->taskExec('cypress')->args('run', '--env')->rawArg('BASE_PATH=' . $base_path)->run();
-    }
+    $this->runVisualRegressionTests();
+  }
 
-    private function openCypressTestResults($test_url) {
-        $this
-            ->taskExec('cypress')
-            ->args('open', '--env')
-            ->rawArg('BASE_PATH=' . $test_url)
-            ->rawArg('--project ./.tests')
-            ->run();
-    }
+  private function generateReferenceImages()
+  {
+    $this->taskExec('backstop')->args('reference', '--config=' . $this->backstop_config)->run();
+  }
+
+  private function runVisualRegressionTests()
+  {
+    // Run the tests set up in the ROOT/.tests/elements.json file.
+    $this->taskExec('backstop')->args('test', '--config=' . $this->backstop_config)->run();
+    $this->taskExec('backstop')->args('openReport', '--config=' . $this->backstop_config)->run();
+  }
+
+  private function runCypressTests($base_path)
+  {
+    $this->taskExec('cypress')->args('run', '--env')->rawArg('BASE_PATH=' . $base_path)->run();
+  }
+
+  private function openCypressTestResults($test_url)
+  {
+    $this
+      ->taskExec('cypress')
+      ->args('open', '--env')
+      ->rawArg('BASE_PATH=' . $test_url)
+      ->rawArg('--project ./.tests')
+      ->run();
+  }
 }

--- a/src/Traits/SiteInfo.php
+++ b/src/Traits/SiteInfo.php
@@ -5,36 +5,43 @@ namespace RootidCLI\Traits;
 trait SiteInfo
 {
 
-    function getSite($site_name = '')
-    {
-        $out = shell_exec("terminus site:info {$site_name} --format=json");
-        $out = json_decode($out);
-        return $out;
+  function getSite($site_name = '')
+  {
+    $out = shell_exec("terminus site:info {$site_name} --format=json");
+    $out = json_decode($out);
+    return $out;
+  }
+
+  /**
+   * Returns an array of site slugs that the user has access to.
+   */
+  function getSiteList()
+  {
+    $sites = shell_exec('terminus site:list --format=json');
+    $sites = json_decode($sites);
+    $output = [];
+
+    foreach ($sites as $key => $site) {
+      $output[] = $site->name;
     }
 
-    /**
-     * Returns an array of site slugs that the user has access to.
-     */
-    function getSiteList()
-    {
-        $sites = shell_exec('terminus site:list --format=json');
-        $sites = json_decode($sites);
-        $output = [];
+    return $output;
+  }
 
-        foreach ($sites as $key => $site) {
-            $output[] = $site->name;
-        }
+  function getLocalSiteRoot($site)
+  {
+    $path = 'http://' . $site->name . '.' . \Robo\Robo::config()->get('options.local_domain');
+    // if(\Robo\Robo::config()->get('web_docroot')) {
+    //     $path .= '/web';
+    // }
 
-        return $output;
-    }
+    return $path;
+  }
 
-    function getLocalSiteRoot($site)
-    {
-        $path = 'http://' . $site->name . '.' . \Robo\Robo::config()->get('options.local_domain');
-        // if(\Robo\Robo::config()->get('web_docroot')) {
-        //     $path .= '/web';
-        // }
-
-        return $path;
-    }
+  function getSiteEnvs($site)
+  {
+    $temp = shell_exec("terminus env:list --format list --fields ID {$site->name}");
+    $out = array_filter(preg_split("/(\r\n|\r|\n)/", $temp));
+    return $out;
+  }
 }


### PR DESCRIPTION
Use terminus to check to see if environment set in --env flag exists
Allow an environment to be used as selector in --ref and --test flags
If an environment is used as a selector, preface the url with "https://rootid:rootid@"